### PR TITLE
Update for newest version of Sickchill that uses virtualenv

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,20 +1,24 @@
 #!/bin/sh
 
 echo "Create location for sickchill"
-mkdir /usr/local/app
+mkdir -p /usr/local/app
 
 echo "Download sickchill repo"
 git clone https://github.com/SickChill/SickChill.git /usr/local/app/sickchill
 
-echo "Install dependencies"
-pip install -r /usr/local/app/sickchill/requirements.txt
+echo "Updating dependencies"
+pip install --upgrade pip
+pip install --upgrade virtualenv
 
 echo "Create sickchill user"
 pw user add sickchill -c "Sickchill" -d /nonexistent -s /usr/bin/nologin -w no
 chown -R sickchill:sickchill /usr/local/app/sickchill
 
+mkdir -p /.cargo
+chown -R sickchill:sickchill /.cargo
+
 echo "Installing SickChill service"
-mkdir /usr/local/etc/rc.d
+mkdir -p /usr/local/etc/rc.d
 cp /usr/local/app/sickchill/contrib/runscripts/init.freebsd /usr/local/etc/rc.d/sickchill
 
 echo "Executing SickChill service"


### PR DESCRIPTION
The newest version of Sickchill now uses python virtualenv and needs an update to the install script to account for this.

Goes with https://github.com/ix-plugin-hub/iocage-plugin-index/pull/248

Discussion: https://github.com/SickChill/SickChill/issues/7253